### PR TITLE
Subscribe exported services when istiod subscribes MCP

### DIFF
--- a/cmd/federation-controller/main.go
+++ b/cmd/federation-controller/main.go
@@ -120,7 +120,7 @@ func main() {
 	serviceController := startControllers(ctx, clientset, cfg, informerFactory, fdsPushRequests, mcpPushRequests)
 
 	federationServer := adss.NewServer(
-		&adss.ServerOpts{Port: 15020, ServerID: "federation"},
+		&adss.ServerOpts{Port: 15020, ServerID: "fds"},
 		fdsPushRequests,
 		nil,
 		federation.NewExportedServicesGenerator(*cfg, informerFactory),
@@ -148,9 +148,11 @@ func main() {
 		}
 		if federationClient != nil {
 			onNewSubscriber = func() {
-				if federationClient.Run(); err != nil {
-					klog.Error("Error starting ADS client: ", err)
-				}
+				go func() {
+					if err := federationClient.Run(); err != nil {
+						klog.Error("failed to start FDS client: ", err)
+					}
+				}()
 			}
 		}
 	}

--- a/examples/README.md
+++ b/examples/README.md
@@ -121,10 +121,10 @@ cat examples/importing-controller.yaml | sed -e "s/{{.federationControllerIP}}/$
 1. Enable mTLS, deploy `sleep` the east cluster and `httpbin` in the west cluster and export `httpbin`:
 ```shell
 keast apply -f examples/mtls.yaml -n istio-system
-kwest apply -f examples/mtls.yaml -n istio-system
 keast create namespace sleep
 keast label namespace sleep istio-injection=enabled
 keast apply -f https://raw.githubusercontent.com/istio/istio/release-1.22/samples/sleep/sleep.yaml -n sleep
+kwest apply -f examples/mtls.yaml -n istio-system
 kwest create namespace httpbin
 kwest label namespace httpbin istio-injection=enabled
 kwest apply -f https://raw.githubusercontent.com/istio/istio/release-1.22/samples/httpbin/httpbin.yaml -n httpbin

--- a/internal/pkg/xds/adss/adss_handler.go
+++ b/internal/pkg/xds/adss/adss_handler.go
@@ -58,6 +58,8 @@ func (adss *adsServer) StreamAggregatedResources(downstream DiscoveryStream) err
 
 	adss.subscribers.Store(sub.id, sub)
 
+	// TODO: this should be executed only on first subscription, because we need only 1 FDS subscription for n MCP subscriptions.
+	// However, new MCP subscription should trigger full FDS push, so then we need to send DiscoveryRequest with newer version.
 	if adss.onNewSubscriber != nil {
 		go adss.onNewSubscriber()
 	}

--- a/internal/pkg/xds/adss/adss_handler.go
+++ b/internal/pkg/xds/adss/adss_handler.go
@@ -61,7 +61,7 @@ func (adss *adsServer) StreamAggregatedResources(downstream DiscoveryStream) err
 	// TODO: this should be executed only on first subscription, because we need only 1 FDS subscription for n MCP subscriptions.
 	// However, new MCP subscription should trigger full FDS push, so then we need to send DiscoveryRequest with newer version.
 	if adss.onNewSubscriber != nil {
-		go adss.onNewSubscriber()
+		adss.onNewSubscriber()
 	}
 	go adss.recvFromStream(int64(sub.id), downstream)
 

--- a/internal/pkg/xds/adss/grpc_server.go
+++ b/internal/pkg/xds/adss/grpc_server.go
@@ -75,7 +75,6 @@ loop:
 	for {
 		select {
 		case <-ctx.Done():
-			// TODO: move to the second routinesGroup.Go
 			s.ads.closeSubscribers()
 			break loop
 

--- a/internal/pkg/xds/adss/grpc_server.go
+++ b/internal/pkg/xds/adss/grpc_server.go
@@ -24,20 +24,24 @@ type ServerOpts struct {
 	ServerID string
 }
 
-func NewServer(opts *ServerOpts, pushRequests <-chan xds.PushRequest, handlers ...RequestHandler) *Server {
+func NewServer(opts *ServerOpts, pushRequests <-chan xds.PushRequest, onNewSubscriber func(), handlers ...RequestHandler) *Server {
 	// TODO: handle nil opts
 	grpcServer := grpc.NewServer()
 	handlerMap := make(map[string]RequestHandler)
 	for _, g := range handlers {
 		handlerMap[g.GetTypeUrl()] = g
 	}
-	adsServer := &adsServer{handlers: handlerMap, serverID: opts.ServerID}
+	ads := &adsServer{
+		handlers:        handlerMap,
+		onNewSubscriber: onNewSubscriber,
+		serverID:        opts.ServerID,
+	}
 
-	discovery.RegisterAggregatedDiscoveryServiceServer(grpcServer, adsServer)
+	discovery.RegisterAggregatedDiscoveryServiceServer(grpcServer, ads)
 
 	return &Server{
 		grpc:         grpcServer,
-		ads:          adsServer,
+		ads:          ads,
 		pushRequests: pushRequests,
 		opts:         opts,
 	}
@@ -71,6 +75,7 @@ loop:
 	for {
 		select {
 		case <-ctx.Done():
+			// TODO: move to the second routinesGroup.Go
 			s.ads.closeSubscribers()
 			break loop
 


### PR DESCRIPTION
When MCP server and FDS client were started independently, there could happen the following order of events:
1. MCP server was started.
2. FDS client was started.
3. FDS client received exported services.
4. MCP skipped pushing ServiceEntry resources for the received exported services, because there were no subscribers.
5. Istio connected to MCP.
6. MCP pushed 0 ServiceEntry resources.

In such a case, importing mesh was out of sync. To avoid this issue, we can start FDS client after receiving MCP subscription from istiod. This is still not fully correct, because we should start only 1 FDS client for all MCP subscriptions and just trigger FDS push on new MCP subscriptions, but this could be done in a follow-up PR.