### PR TITLE
fix: excludes IDE folders from version control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,9 @@
 out
+
+# IDE configs
+.idea/
+.vscode/
+
 # demo output
 Makefile.selfsigned.mk
 common.mk


### PR DESCRIPTION
This change ensures that IDE specific settings are not versioned. They often contain dev or system-specific settings that are irrelevant for the project. Making such files versioned might result in unnecessary merge conflicts and clutter the PRs.

This PR excludes VS Code and GoLand settings through `.gitignore`.