### PR TITLE
fix(make): defines default target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 OUT := $(shell pwd)
 
-.PHONY: build test
+.PHONY: default
+default: build test
 
 export TAG ?= latest
 export HUB ?= quay.io/jewertow


### PR DESCRIPTION
Make processes targets in order of their appearance in the `Makefile` [1] and executed first rule not prefixed with `.`.

The current definition of the "default" target is a `.PHONY` which effectively means that only `build` will be executed, as this is the first matching target.

To ensure both `build` and `test` are invoked the `default` phony target is defined instead, as the first one in the `Makefile`.

[1] https://www.gnu.org/software/make/manual/html_node/How-Make-Works.html