### PR TITLE
fix(make): defines cmd targets as PHONY

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,13 +7,16 @@ export TAG ?= latest
 export HUB ?= quay.io/jewertow
 export ISTIO_VERSION ?= 1.23.0
 
+.PHONY: build
 build:
 	go get ./...
 	go build -C cmd/federation-controller -o "${OUT}/out/"
 
+.PHONY: test
 test:
 	go test ./...
 
+.PHONY: docker
 docker: build
 	docker build -t $(HUB)/federation-controller:$(TAG) -f build/Dockerfile .
 
@@ -24,12 +27,15 @@ OUT_DIR=internal/api
 proto:
 	protoc --proto_path=$(PROTO_DIR) --go_out=$(OUT_DIR) --go-grpc_out=$(OUT_DIR) --golang-deepcopy_out=:$(OUT_DIR) $(PROTO_DIR)/**/*.proto
 
+.PHONY: gen-istio-manifests
 gen-istio-manifests:
 	bash test/scripts/generate_istio_manifests.sh $(ISTIO_VERSION)
 
+.PHONY: kind-clusters
 kind-clusters:
 	bash test/scripts/kind_provisioner.sh $(ISTIO_VERSION)
 
+.PHONY: e2e-test
 e2e-test:
 	go test -tags=integ -run TestTraffic ./test/e2e \
 		--istio.test.hub=docker.io/istio\
@@ -38,4 +44,5 @@ e2e-test:
 		--istio.test.kube.networkTopology=0:east-network,1:west-network\
 		--istio.test.onlyWorkloads=standard
 
+.PHONY: e2e
 e2e: kind-clusters e2e-test


### PR DESCRIPTION
Each target which is not representing an actual file should be marked as `.PHONY`.

Otherwise running e.g. `make build` twice would result in subsequent execution being skipped with:

```sh
$ make build
make: 'build' is up to date.
```

which is not desired (coincidently we have both `build` and `test` folders in this project).

This change ensures all fake/phony targets are marked respectively and so they are executed each time.