### PR TITLE
ci: introduces basic unit test job

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,12 @@
+name: controller-build
+on: [push, pull_request]
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - run: make test

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ build:
 	go build -C cmd/federation-controller -o "${OUT}/out/"
 
 .PHONY: test
-test:
+test: build
 	go test ./...
 
 .PHONY: docker


### PR DESCRIPTION
In order to ensure healthy code base we can automate checks as GitHub actions. This way we can spot defects early and make sure all new changes are not breaking anything.

This change brings a simple job which for each PR or push to main branch will trigger unit tests and binary compilation (default target).