### PR TITLE
Move creating Istio resources to istio.ConfigFactory

### DIFF
--- a/cmd/federation-controller/main.go
+++ b/cmd/federation-controller/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/jewertow/federation/internal/pkg/config"
 	"github.com/jewertow/federation/internal/pkg/fds"
 	"github.com/jewertow/federation/internal/pkg/informer"
+	"github.com/jewertow/federation/internal/pkg/istio"
 	"github.com/jewertow/federation/internal/pkg/mcp"
 	"github.com/jewertow/federation/internal/pkg/xds"
 	"github.com/jewertow/federation/internal/pkg/xds/adsc"
@@ -141,6 +142,8 @@ func main() {
 	}
 	serviceController.RunAndWait(ctx.Done())
 
+	istioConfigFactory := istio.NewConfigFactory(*cfg, serviceLister)
+
 	triggerFDSPushOnNewSubscription := func() {
 		fdsPushRequests <- xds.PushRequest{
 			TypeUrl: xds.ExportedServiceTypeUrl,
@@ -185,7 +188,7 @@ func main() {
 		&adss.ServerOpts{Port: 15010, ServerID: "mcp"},
 		mcpPushRequests,
 		onNewMCPSubscription,
-		mcp.NewGatewayResourceGenerator(*cfg, serviceLister),
+		mcp.NewGatewayResourceGenerator(istioConfigFactory),
 	)
 	if err := mcpServer.Run(ctx); err != nil {
 		log.Fatalf("Error running XDS server: %v", err)

--- a/cmd/federation-controller/main.go
+++ b/cmd/federation-controller/main.go
@@ -169,7 +169,7 @@ func main() {
 				TypeUrl: xds.ExportedServiceTypeUrl,
 			}},
 			Handlers: map[string]adsc.ResponseHandler{
-				xds.ExportedServiceTypeUrl: mcp.NewImportedServiceHandler(cfg, serviceLister, mcpPushRequests),
+				xds.ExportedServiceTypeUrl: mcp.NewImportedServiceHandler(istioConfigFactory, mcpPushRequests),
 			},
 		})
 		if err != nil {

--- a/examples/exporting-controller.yaml
+++ b/examples/exporting-controller.yaml
@@ -4,7 +4,7 @@ federation:
       controlPlane:
         namespace: "istio-system"
       gateways:
-        dataPlane:
+        ingress:
           selector:
             istio: eastwestgateway
   exportedServiceSet:

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	google.golang.org/grpc v1.65.0
 	google.golang.org/protobuf v1.34.2
 	istio.io/api v1.22.1
+	istio.io/client-go v1.22.1-0.20240524024404-e48447329f77
 	istio.io/istio v0.0.0-20240601204907-a1a76b8e75f8
 	k8s.io/api v0.30.3
 	k8s.io/apimachinery v0.30.3
@@ -192,7 +193,6 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	helm.sh/helm/v3 v3.14.3 // indirect
-	istio.io/client-go v1.22.1-0.20240524024404-e48447329f77 // indirect
 	k8s.io/apiextensions-apiserver v0.30.0 // indirect
 	k8s.io/apiserver v0.30.0 // indirect
 	k8s.io/cli-runtime v0.30.0 // indirect

--- a/internal/pkg/config/federation_config.go
+++ b/internal/pkg/config/federation_config.go
@@ -6,18 +6,18 @@ type Federation struct {
 	ImportedServiceSet ImportedServiceSet
 }
 
-func (f *Federation) GetLocalDataPlaneGatewayNamespace() string {
-	if f.MeshPeers.Local.Gateways.DataPlane.Namespace == "" {
+func (f *Federation) GetLocalIngressGatewayNamespace() string {
+	if f.MeshPeers.Local.Gateways.Ingress.Namespace == "" {
 		return f.MeshPeers.Local.ControlPlane.Namespace
 	}
-	return f.MeshPeers.Local.Gateways.DataPlane.Namespace
+	return f.MeshPeers.Local.Gateways.Ingress.Namespace
 }
 
-func (f *Federation) GetLocalDataPlaneGatewayPort() uint32 {
-	if f.MeshPeers.Local.Gateways.DataPlane.Port == 0 {
+func (f *Federation) GetLocalIngressGatewayPort() uint32 {
+	if f.MeshPeers.Local.Gateways.Ingress.Port == 0 {
 		return defaultDataPlanePort
 	}
-	return f.MeshPeers.Local.Gateways.DataPlane.Port
+	return f.MeshPeers.Local.Gateways.Ingress.Port
 }
 
 func (f *Federation) GetRemoteDataPlaneGatewayPort() uint32 {

--- a/internal/pkg/config/mesh_peer.go
+++ b/internal/pkg/config/mesh_peer.go
@@ -21,10 +21,10 @@ type ControlPlane struct {
 }
 
 type Gateways struct {
-	DataPlane *LocalDataPlaneGateway `yaml:"dataPlane"`
+	Ingress *LocalGateway `yaml:"ingress"`
 }
 
-type LocalDataPlaneGateway struct {
+type LocalGateway struct {
 	Namespace string            `yaml:"namespace"`
 	Port      uint32            `yaml:"port"`
 	Selector  map[string]string `yaml:"selector"`

--- a/internal/pkg/istio/config_factory.go
+++ b/internal/pkg/istio/config_factory.go
@@ -1,0 +1,69 @@
+package istio
+
+import (
+	"fmt"
+	"sort"
+
+	istionetv1alpha3 "istio.io/api/networking/v1alpha3"
+	"istio.io/client-go/pkg/apis/networking/v1alpha3"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	v1 "k8s.io/client-go/listers/core/v1"
+
+	"github.com/jewertow/federation/internal/pkg/config"
+)
+
+type ConfigFactory struct {
+	cfg           config.Federation
+	serviceLister v1.ServiceLister
+}
+
+func NewConfigFactory(cfg config.Federation, serviceLister v1.ServiceLister) *ConfigFactory {
+	return &ConfigFactory{
+		cfg:           cfg,
+		serviceLister: serviceLister,
+	}
+}
+
+func (cf *ConfigFactory) GenerateIngressGateway() (*v1alpha3.Gateway, error) {
+	var hosts []string
+	for _, exportLabelSelector := range cf.cfg.ExportedServiceSet.GetLabelSelectors() {
+		matchLabels := labels.SelectorFromSet(exportLabelSelector.MatchLabels)
+		services, err := cf.serviceLister.List(matchLabels)
+		if err != nil {
+			return nil, fmt.Errorf("error listing services (selector=%s): %v", matchLabels, err)
+		}
+		for _, svc := range services {
+			hosts = append(hosts, fmt.Sprintf("%s.%s.svc.cluster.local", svc.Name, svc.Namespace))
+		}
+	}
+	if len(hosts) == 0 {
+		return nil, nil
+	}
+	// ServiceLister.List is not idempotent, so to avoid redundant XDS push from Istio to proxies,
+	// we must return hostnames in the same order.
+	sort.Strings(hosts)
+
+	gateway := &v1alpha3.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "federation-ingress-gateway",
+			Namespace: cf.cfg.GetLocalIngressGatewayNamespace(),
+		},
+		Spec: istionetv1alpha3.Gateway{
+			Selector: cf.cfg.MeshPeers.Local.Gateways.Ingress.Selector,
+			Servers: []*istionetv1alpha3.Server{{
+				Hosts: hosts,
+				Port: &istionetv1alpha3.Port{
+					Number:   cf.cfg.GetLocalIngressGatewayPort(),
+					Name:     "tls",
+					Protocol: "TLS",
+				},
+				Tls: &istionetv1alpha3.ServerTLSSettings{
+					Mode: istionetv1alpha3.ServerTLSSettings_AUTO_PASSTHROUGH,
+				},
+			}},
+		},
+	}
+
+	return gateway, nil
+}

--- a/internal/pkg/istio/config_factory.go
+++ b/internal/pkg/istio/config_factory.go
@@ -6,10 +6,12 @@ import (
 
 	istionetv1alpha3 "istio.io/api/networking/v1alpha3"
 	"istio.io/client-go/pkg/apis/networking/v1alpha3"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	v1 "k8s.io/client-go/listers/core/v1"
 
+	"github.com/jewertow/federation/internal/api/federation/v1alpha1"
 	"github.com/jewertow/federation/internal/pkg/config"
 )
 
@@ -66,4 +68,74 @@ func (cf *ConfigFactory) GenerateIngressGateway() (*v1alpha3.Gateway, error) {
 	}
 
 	return gateway, nil
+}
+
+func (cf *ConfigFactory) GenerateServiceAndWorkloadEntries(importedServices []*v1alpha1.ExportedService) ([]*v1alpha3.ServiceEntry, []*v1alpha3.WorkloadEntry, error) {
+	var serviceEntries []*v1alpha3.ServiceEntry
+	var workloadEntries []*v1alpha3.WorkloadEntry
+	for _, importedSvc := range importedServices {
+		// enable Istio mTLS
+		importedSvc.Labels["security.istio.io/tlsMode"] = "istio"
+
+		_, err := cf.serviceLister.Services(importedSvc.Namespace).Get(importedSvc.Name)
+		if err != nil {
+			if !errors.IsNotFound(err) {
+				return nil, nil, fmt.Errorf("failed to get Service %s/%s: %v", importedSvc.Name, importedSvc.Namespace, err)
+			}
+			// Service doesn't exist - create ServiceEntry.
+			var ports []*istionetv1alpha3.ServicePort
+			for _, port := range importedSvc.Ports {
+				ports = append(ports, &istionetv1alpha3.ServicePort{
+					Name:       port.Name,
+					Number:     port.Number,
+					Protocol:   port.Protocol,
+					TargetPort: port.TargetPort,
+				})
+			}
+			serviceEntries = append(serviceEntries, &v1alpha3.ServiceEntry{
+				ObjectMeta: metav1.ObjectMeta{
+					// TODO: add peer name to ensure uniqueness when more than 2 peers are connected
+					Name:      fmt.Sprintf("import_%s_%s", importedSvc.Name, importedSvc.Namespace),
+					Namespace: cf.cfg.MeshPeers.Local.ControlPlane.Namespace,
+				},
+				Spec: istionetv1alpha3.ServiceEntry{
+					Hosts:      []string{fmt.Sprintf("%s.%s.svc.cluster.local", importedSvc.Name, importedSvc.Namespace)},
+					Ports:      ports,
+					Endpoints:  cf.makeWorkloadEntrySpecs(importedSvc.Ports, importedSvc.Labels),
+					Location:   istionetv1alpha3.ServiceEntry_MESH_INTERNAL,
+					Resolution: istionetv1alpha3.ServiceEntry_STATIC,
+				},
+			})
+		} else {
+			// Service already exists - create WorkloadEntries.
+			workloadEntrySpecs := cf.makeWorkloadEntrySpecs(importedSvc.Ports, importedSvc.Labels)
+			for idx, weSpec := range workloadEntrySpecs {
+				workloadEntries = append(workloadEntries, &v1alpha3.WorkloadEntry{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      fmt.Sprintf("import_%s_%d", importedSvc.Name, idx),
+						Namespace: importedSvc.Namespace,
+					},
+					Spec: *weSpec.DeepCopy(),
+				})
+			}
+		}
+	}
+	return serviceEntries, workloadEntries, nil
+}
+
+func (cf *ConfigFactory) makeWorkloadEntrySpecs(ports []*v1alpha1.ServicePort, labels map[string]string) []*istionetv1alpha3.WorkloadEntry {
+	var workloadEntries []*istionetv1alpha3.WorkloadEntry
+	for _, addr := range cf.cfg.MeshPeers.Remote.DataPlane.Addresses {
+		we := &istionetv1alpha3.WorkloadEntry{
+			Address: addr,
+			Network: cf.cfg.MeshPeers.Remote.Network,
+			Labels:  labels,
+			Ports:   make(map[string]uint32, len(ports)),
+		}
+		for _, p := range ports {
+			we.Ports[p.Name] = cf.cfg.GetRemoteDataPlaneGatewayPort()
+		}
+		workloadEntries = append(workloadEntries, we)
+	}
+	return workloadEntries
 }

--- a/internal/pkg/istio/config_factory_test.go
+++ b/internal/pkg/istio/config_factory_test.go
@@ -1,1 +1,0 @@
-package istio

--- a/internal/pkg/istio/config_factory_test.go
+++ b/internal/pkg/istio/config_factory_test.go
@@ -1,0 +1,1 @@
+package istio

--- a/internal/pkg/mcp/gateway_generator.go
+++ b/internal/pkg/mcp/gateway_generator.go
@@ -2,30 +2,24 @@ package mcp
 
 import (
 	"fmt"
-	"sort"
 
-	"github.com/jewertow/federation/internal/pkg/config"
+	"github.com/jewertow/federation/internal/pkg/istio"
 	"github.com/jewertow/federation/internal/pkg/xds"
 	"github.com/jewertow/federation/internal/pkg/xds/adss"
 	"google.golang.org/protobuf/types/known/anypb"
-	istionetv1alpha3 "istio.io/api/networking/v1alpha3"
 	istiocfg "istio.io/istio/pkg/config"
-	"k8s.io/apimachinery/pkg/labels"
-	v1 "k8s.io/client-go/listers/core/v1"
 )
 
 var _ adss.RequestHandler = (*GatewayResourceGenerator)(nil)
 
 // GatewayResourceGenerator generates Istio Gateway for all Services matching export rules.
 type GatewayResourceGenerator struct {
-	cfg           config.Federation
-	serviceLister v1.ServiceLister
+	cf *istio.ConfigFactory
 }
 
-func NewGatewayResourceGenerator(cfg config.Federation, serviceLister v1.ServiceLister) *GatewayResourceGenerator {
+func NewGatewayResourceGenerator(cf *istio.ConfigFactory) *GatewayResourceGenerator {
 	return &GatewayResourceGenerator{
-		cfg:           cfg,
-		serviceLister: serviceLister,
+		cf: cf,
 	}
 }
 
@@ -34,44 +28,19 @@ func (g *GatewayResourceGenerator) GetTypeUrl() string {
 }
 
 func (g *GatewayResourceGenerator) GenerateResponse() ([]*anypb.Any, error) {
-	var hosts []string
-	for _, exportLabelSelector := range g.cfg.ExportedServiceSet.GetLabelSelectors() {
-		matchLabels := labels.SelectorFromSet(exportLabelSelector.MatchLabels)
-		services, err := g.serviceLister.List(matchLabels)
-		if err != nil {
-			return nil, fmt.Errorf("error listing services (selector=%s): %v", matchLabels, err)
-		}
-		for _, svc := range services {
-			hosts = append(hosts, fmt.Sprintf("%s.%s.svc.cluster.local", svc.Name, svc.Namespace))
-		}
+	gw, err := g.cf.GenerateIngressGateway()
+	if err != nil {
+		return nil, fmt.Errorf("error generating ingress gateway: %v", err)
 	}
-	if len(hosts) == 0 {
+	if gw == nil {
 		return nil, nil
-	}
-	// ServiceLister.List is not idempotent, so to avoid redundant XDS push from Istio to proxies,
-	// we must return hostnames in the same order.
-	sort.Strings(hosts)
-
-	gwSpec := &istionetv1alpha3.Gateway{
-		Selector: g.cfg.MeshPeers.Local.Gateways.DataPlane.Selector,
-		Servers: []*istionetv1alpha3.Server{{
-			Hosts: hosts,
-			Port: &istionetv1alpha3.Port{
-				Number:   g.cfg.GetLocalDataPlaneGatewayPort(),
-				Name:     "tls",
-				Protocol: "TLS",
-			},
-			Tls: &istionetv1alpha3.ServerTLSSettings{
-				Mode: istionetv1alpha3.ServerTLSSettings_AUTO_PASSTHROUGH,
-			},
-		}},
 	}
 
 	return serialize(&istiocfg.Config{
 		Meta: istiocfg.Meta{
-			Name:      "mcp-federation-ingress-gateway",
-			Namespace: g.cfg.GetLocalDataPlaneGatewayNamespace(),
+			Name:      gw.Name,
+			Namespace: gw.Namespace,
 		},
-		Spec: gwSpec,
+		Spec: &gw.Spec,
 	})
 }

--- a/internal/pkg/mcp/import_handler_test.go
+++ b/internal/pkg/mcp/import_handler_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jewertow/federation/internal/api/federation/v1alpha1"
 	"github.com/jewertow/federation/internal/pkg/config"
 	"github.com/jewertow/federation/internal/pkg/informer"
+	"github.com/jewertow/federation/internal/pkg/istio"
 	"github.com/jewertow/federation/internal/pkg/xds"
 	"golang.org/x/net/context"
 	"google.golang.org/protobuf/proto"
@@ -258,7 +259,7 @@ func TestHandle(t *testing.T) {
 			serviceController.RunAndWait(stopCh)
 
 			mcpPushRequests := make(chan xds.PushRequest)
-			handler := NewImportedServiceHandler(&defaultConfig, serviceLister, mcpPushRequests)
+			handler := NewImportedServiceHandler(istio.NewConfigFactory(defaultConfig, serviceLister), mcpPushRequests)
 
 			// Handle must be called in a goroutine, because mcpPushRequests is an unbuffered channel,
 			// so it's blocked until another goroutine reads from the channel


### PR DESCRIPTION
This change will allow to run the controller as an XDS config source server for Istio or as a standard k8s controller that creates and reconciles Istio resources in the k8s api-server. 